### PR TITLE
Fix Google fonts loading issue on HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 
     <!-- Bootstrap Core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,900' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Roboto:400,900' rel='stylesheet' type='text/css'>
 
     <!-- Custom CSS -->
     <link href="css/crouton.css" rel="stylesheet">


### PR DESCRIPTION
This pull request fixes the error loading Google fonts when site is served through HTTPS, it's visible on https://ylorant.github.io/splitty/